### PR TITLE
fix: armv7 nix built

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,11 +15,13 @@ jobs:
       matrix:
         binary:
           - architecture: x86_64-linux
-            runner: ubuntu-latest
-          - architecture: aarch64-linux
-            runner: ubuntu-latest
-          - architecture: armv7l-linux
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
+          # - architecture: aarch64-linux
+          #   runner: ubuntu-24.04
+          - architecture: aarch64-darwin
+            runner: macos-15
+          - architecture: x86_64-darwin
+            runner: macos-15
     name: Binary ${{ matrix.binary.architecture }}
     uses: ./.github/workflows/build-binaries.yaml
     with:
@@ -50,11 +52,11 @@ jobs:
             The binaries for this PR can be downloaded from:
             ```
             mkdir ./binaries
-            gcloud artifacts files download --project=gnosisvpn-production --location=europe-west3 --repository=rust-binaries gnosis_vpn:${{ steps.vars.outputs.pr_version }}:gnosis_vpn-server-aarch64-linux --destination=./binaries --local-filename=gnosis_vpn-server-aarch64-linux
-
             gcloud artifacts files download --project=gnosisvpn-production --location=europe-west3 --repository=rust-binaries gnosis_vpn:${{ steps.vars.outputs.pr_version }}:gnosis_vpn-server-x86_64-linux --destination=./binaries --local-filename=gnosis_vpn-server-x86_64-linux
 
-            gcloud artifacts files download --project=gnosisvpn-production --location=europe-west3 --repository=rust-binaries gnosis_vpn:${{ steps.vars.outputs.pr_version }}:gnosis_vpn-server-armv7l-linux --destination=./binaries --local-filename=gnosis_vpn-server-armv7l-linux
+            gcloud artifacts files download --project=gnosisvpn-production --location=europe-west3 --repository=rust-binaries gnosis_vpn:${{ steps.vars.outputs.pr_version }}:gnosis_vpn-server-aarch64-darwin --destination=./binaries --local-filename=gnosis_vpn-server-aarch64-darwin
+
+            gcloud artifacts files download --project=gnosisvpn-production --location=europe-west3 --repository=rust-binaries gnosis_vpn:${{ steps.vars.outputs.pr_version }}:gnosis_vpn-server-x86_64-darwin --destination=./binaries --local-filename=gnosis_vpn-server-x86_64-darwin
             ```
   cache-deps:
     name: Cache deps

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
-        "armv7l-linux"
+        "x86_64-darwin"
       ];
       perSystem =
         {
@@ -73,8 +73,8 @@
           systemTargets = {
             "x86_64-linux" = "x86_64-unknown-linux-musl";
             "aarch64-linux" = "aarch64-unknown-linux-musl";
-            "armv7l-linux" = "armv7-unknown-linux-gnueabihf";
             "aarch64-darwin" = "aarch64-apple-darwin";
+            "x86_64-darwin" = "x86_64-apple-darwin";
           };
 
           targetForSystem = builtins.getAttr system systemTargets;
@@ -147,9 +147,9 @@
               CARGO_BUILD_TARGET = "aarch64-unknown-linux-musl";
               CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold";
             };
-            "armv7-unknown-linux-gnueabihf" = {
-              CARGO_PROFILE = "armv7-unknown-linux-gnueabihf";
-              CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold";
+            "x86_64-apple-darwin" = {
+              CARGO_PROFILE = "intelmac";
+              CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
             };
             "aarch64-apple-darwin" = {
               CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";


### PR DESCRIPTION
The arm7 build target was missing in the nix file, but expected in the github merge pipeline