### PR TITLE
fix: Gnosis GPG Signature requires a password

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -39,6 +39,7 @@ jobs:
       gcp_service_account: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      gpg_private_key_password: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
   build-docker:
     name: Docker
     if: github.event.pull_request.merged == true

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,7 +22,7 @@ jobs:
             runner: depot-ubuntu-22.04-4
             build_command: nix build -L .#binary-gnosis_vpn-server-x86_64-linux
           - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-4
+            runner: depot-ubuntu-22.04-4-arm
             build_command: nix build -L .#binary-gnosis_vpn-server-aarch64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -60,7 +60,7 @@ jobs:
             "build_command": "nix run .#docker-gnosis_vpn-server-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-22.04-4",
+            "runner": "depot-ubuntu-22.04-4-arm",
             "architecture": "aarch64-linux",
             "build_command": "nix run .#docker-gnosis_vpn-server-aarch64-linux"
           }

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,7 +22,7 @@ jobs:
             runner: depot-ubuntu-22.04-4
             build_command: nix build -L .#binary-gnosis_vpn-server-x86_64-linux
           - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-4-arm
+            runner: depot-ubuntu-22.04-arm-4
             build_command: nix build -L .#binary-gnosis_vpn-server-aarch64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -60,7 +60,7 @@ jobs:
             "build_command": "nix run .#docker-gnosis_vpn-server-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-22.04-4-arm",
+            "runner": "depot-ubuntu-22.04-arm-4",
             "architecture": "aarch64-linux",
             "build_command": "nix run .#docker-gnosis_vpn-server-aarch64-linux"
           }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,7 +24,7 @@ jobs:
             build_command: nix build -L .#binary-gnosis_vpn-server-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-4-arm
+            runner: depot-ubuntu-22.04-arm-4
             build_command: nix build -L .#binary-gnosis_vpn-server-aarch64-linux
             required_label: "binary:aarch64-linux"
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,6 +44,7 @@ jobs:
       gcp_service_account: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      gpg_private_key_password: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
   build-docker:
     name: Docker
     uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -82,5 +82,5 @@ jobs:
         with:
           source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
           cachix_cache_name: gnosis-vpn-server
-          cachix_auth_token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           command: nix flake check -L --show-trace --max-jobs 1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,7 +24,7 @@ jobs:
             build_command: nix build -L .#binary-gnosis_vpn-server-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-4
+            runner: depot-ubuntu-22.04-4-arm
             build_command: nix build -L .#binary-gnosis_vpn-server-aarch64-linux
             required_label: "binary:aarch64-linux"
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,7 @@ jobs:
       gcp_service_account: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      gpg_private_key_password: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
   build-docker:
     name: Docker
     uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
             runner: depot-ubuntu-22.04-4
             build_command: nix build -L .#binary-gnosis_vpn-server-x86_64-linux
           - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-4
+            runner: depot-ubuntu-22.04-4-arm
             build_command: nix build -L .#binary-gnosis_vpn-server-aarch64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -64,7 +64,7 @@ jobs:
             "build_command": "nix run .#docker-gnosis_vpn-server-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-22.04-4",
+            "runner": "depot-ubuntu-22.04-4-arm",
             "architecture": "aarch64-linux",
             "build_command": "nix run .#docker-gnosis_vpn-server-aarch64-linux"
           }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
             runner: depot-ubuntu-22.04-4
             build_command: nix build -L .#binary-gnosis_vpn-server-x86_64-linux
           - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-4-arm
+            runner: depot-ubuntu-22.04-arm-4
             build_command: nix build -L .#binary-gnosis_vpn-server-aarch64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -64,7 +64,7 @@ jobs:
             "build_command": "nix run .#docker-gnosis_vpn-server-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-22.04-4-arm",
+            "runner": "depot-ubuntu-22.04-arm-4",
             "architecture": "aarch64-linux",
             "build_command": "nix run .#docker-gnosis_vpn-server-aarch64-linux"
           }


### PR DESCRIPTION
- Extend the building to sign the binaries using the password.
- Fix the docker build for platform `aarch-linux`