### PR TITLE
fix: Merge and release workflows do not specify the correcy docker registry

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -67,6 +67,7 @@ jobs:
         ]
       cachix_cache_name: gnosis-vpn-server
       docker_image_name: gnosis_vpn-server
+      docker_gcp_registry: europe-west3-docker.pkg.dev/gnosisvpn-production/docker-images
       docker_image_format: docker
       docker_bucket_sboms: gnosisvpn-production-docker-images-sboms
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,7 @@ jobs:
         ]
       cachix_cache_name: gnosis-vpn-server
       docker_image_name: gnosis_vpn-server
+      docker_gcp_registry: europe-west3-docker.pkg.dev/gnosisvpn-production/docker-images
       docker_image_format: docker
       docker_bucket_sboms: gnosisvpn-production-docker-images-sboms
     secrets:


### PR DESCRIPTION
The merge workflow fails because it tries to publish in the wrong Docker registry.