### PR TITLE
fix: Adapt to the new parameters of the release-version-v3 action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,6 @@ jobs:
         with:
           source_branch: ${{ github.ref_name }}
           release_type: ${{ inputs.release_type }}
-          package_name: gnosis_vpn-server
           cachix_cache_name: gnosis-vpn-server
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
@@ -99,5 +98,5 @@ jobs:
           zulip_channel: GnosisVPN
           zulip_topic: Releases
           gcp_service_account: ${{ secrets.GCP_SA_GITHUB_ACTIONS }}
-          gcp_project: gnosisvpn-production
-          github_token: ${{ secrets.BOT_TOKEN }}
+          gcp_artifact_package: gnosis_vpn-server
+          github_token: ${{ secrets.GNOSIS_GITHUB_WORKFLOW_TOKEN }}


### PR DESCRIPTION
The action `release-version-v3` made some breaking changes in the input parameters that were not applied.