### PR TITLE
fix(renovate): enable nix flake.lock updates and disable broken pinDi…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,8 @@
     },
     {
       "matchManagers": ["nix"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "nix flake updates"
+      "groupName": "nix flake updates",
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
…gest

Dropped matchUpdateTypes from the nix rule — nix flake inputs tracking branches only generate digest/pinDigest updates, never minor/patch, so the old filter silently suppressed all flake.lock updates.

Added pinDigests: false because renovate cannot do the initial branch-name → commit-hash transformation in flake.nix; the current digest lives only in flake.lock, not in the URL, so the replacement is always a no-op and errors out.