### PR TITLE
fix(docker): only sysctl -w ip_forward when not already set

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ The resulting binary is in `result/bin/`:
 ```
 > ls -la result/bin/
 total 6736
--r-xr-xr-x 1 root root 6886689  1. Jan 1970  gnosis_vpn-server
+-r-xr-xr-x 1 root root 6886690  1. Jan 1970  gnosis_vpn-server
 ```

--- a/docker/wggvpn.conf
+++ b/docker/wggvpn.conf
@@ -3,7 +3,7 @@ Address = 10.129.0.1/32
 ListenPort = 51820
 PrivateKey = <private key>
 # NAT so connected clients can reach the external network via the container's eth0
-PostUp = sysctl -w net.ipv4.ip_forward=1
+PostUp = sh -c '[ "$(cat /proc/sys/net/ipv4/ip_forward)" = 1 ] || sysctl -w net.ipv4.ip_forward=1'
 PostUp = iptables -t nat -C POSTROUTING -s 10.129.0.0/24 -o eth0 -j MASQUERADE || iptables -t nat -A POSTROUTING -s 10.129.0.0/24 -o eth0 -j MASQUERADE
 PostUp = iptables -C FORWARD -i %i -o eth0 -j ACCEPT || iptables -I FORWARD -i %i -o eth0 -j ACCEPT
 PostUp = iptables -C FORWARD -i eth0 -o %i -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || iptables -I FORWARD -i eth0 -o %i -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT

--- a/docker/wggvpn.conf
+++ b/docker/wggvpn.conf
@@ -3,7 +3,7 @@ Address = 10.129.0.1/32
 ListenPort = 51820
 PrivateKey = <private key>
 # NAT so connected clients can reach the external network via the container's eth0
-PostUp = sh -c '[ "$(cat /proc/sys/net/ipv4/ip_forward)" = 1 ] || sysctl -w net.ipv4.ip_forward=1'
+PostUp = [ "$(cat /proc/sys/net/ipv4/ip_forward)" = 1 ] || sysctl -w net.ipv4.ip_forward=1
 PostUp = iptables -t nat -C POSTROUTING -s 10.129.0.0/24 -o eth0 -j MASQUERADE || iptables -t nat -A POSTROUTING -s 10.129.0.0/24 -o eth0 -j MASQUERADE
 PostUp = iptables -C FORWARD -i %i -o eth0 -j ACCEPT || iptables -I FORWARD -i %i -o eth0 -j ACCEPT
 PostUp = iptables -C FORWARD -i eth0 -o %i -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || iptables -I FORWARD -i eth0 -o %i -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT


### PR DESCRIPTION
wg-quick's unconditional write to /proc/sys/net/ipv4/ip_forward fails with Read-only file system on hosts where the value is already 1 but the file isn't rewritable at runtime, aborting the whole interface up.